### PR TITLE
69 list categories on the home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "axios": "^1.4.0",
     "classnames": "^2.3.2",
     "keen-slider": "^6.8.5",
-    "lucide-react": "^0.223.0",
+    "lucide-react": "^0.258.0",
     "next": "13.4.2",
     "plaiceholder": "^3.0.0",
     "postcss": "8.4.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@hookform/resolvers':
     specifier: ^3.1.0
@@ -57,8 +53,8 @@ dependencies:
     specifier: ^6.8.5
     version: 6.8.5
   lucide-react:
-    specifier: ^0.223.0
-    version: 0.223.0(react@18.2.0)
+    specifier: ^0.258.0
+    version: 0.258.0(react@18.2.0)
   next:
     specifier: 13.4.2
     version: 13.4.2(react-dom@18.2.0)(react@18.2.0)
@@ -1595,8 +1591,8 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /lucide-react@0.223.0(react@18.2.0):
-    resolution: {integrity: sha512-4ST5mVxlVxsXKh5dEXa0rgXOtCYmbe5iz7uKN9+ugOLYXrbX/BhyD82Js5rAzLyBxTIhgejEsg+kICw8neC+rQ==}
+  /lucide-react@0.258.0(react@18.2.0):
+    resolution: {integrity: sha512-3evnpKadBrjLr2HHJ66eDZ1y0vPS6pm8NiNDaLqhddUUyJGnA+lfDPZfbVkuAFq7Xaa1TEy7Sg17sM7mHpMKrA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
     dependencies:
@@ -2337,3 +2333,7 @@ packages:
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/app/(home)/_components/CommonCategoriesList.tsx
+++ b/src/app/(home)/_components/CommonCategoriesList.tsx
@@ -1,17 +1,16 @@
-import { homeBrowseByCategory } from "@/mock/category";
+import { getMostPopularCategories } from "@/api/category";
 import { Routes } from "@/utils/constants/routes";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 import CommonCategoryCard from "./CommonCategoryCard";
 
-// TODO: Fetch the most popular categories from the API
-
-export default function CommonCategoriesList() {
+export default async function PopularCategories() {
+  const categories = await getMostPopularCategories();
   return (
     <section className="mt-10 lg:mt-28">
       <div className="lg:flex items-center justify-between lg:mb-20">
         <h2 className="text-3xl font-bold mb-14 lg:mb-0">
-          Procurar prestadores por categoria
+          Categorias Mais Populares
         </h2>
         <Link
           href={Routes.categories}
@@ -22,8 +21,8 @@ export default function CommonCategoriesList() {
         </Link>
       </div>
       <article className="mt-5 flex overflow-auto gap-2 lg:grid grid-cols-4 lg:gap-7 lg:mt-0 lg:py-4 lg:overflow-hidden">
-        {homeBrowseByCategory.map((category) => (
-          <CommonCategoryCard {...category} key={category.id} />
+        {categories.map((category) => (
+          <CommonCategoryCard category={category} key={category.slug} />
         ))}
       </article>
     </section>

--- a/src/app/(home)/_components/CommonCategoryCard.tsx
+++ b/src/app/(home)/_components/CommonCategoryCard.tsx
@@ -1,8 +1,8 @@
 import { GetMostPopularCategoriesResponseBody } from "@/api/types/response";
 import { Routes } from "@/utils/constants/routes";
 import { formatToNumber } from "@/utils/intl";
-import { BoxSelect } from "lucide-react";
 import Link from "next/link";
+import PopularCategoryIconSelector from "./PopularCategoryIconSelector";
 
 type Props = {
   category: GetMostPopularCategoriesResponseBody[number];
@@ -16,10 +16,7 @@ export default function CommonCategoryCard({ category }: Props) {
       className="px-7 py-10 space-y-7 flex-1 border border-neutral-200 lg:border-neutral-50 lg:shadow-lg hover:bg-neutral-200/40 duration-300 cursor-pointer"
     >
       <div className="relative  inline-block">
-        <BoxSelect
-          size={40}
-          className="text-primary-600 relative category-bg-icon "
-        />
+        <PopularCategoryIconSelector slug={slug} />
         <div className="absolute -z-10 -right-3 -bottom-2 bg-primary-100 w-10 h-10 rounded-full" />
       </div>
       <div className="space-y-1">

--- a/src/app/(home)/_components/CommonCategoryCard.tsx
+++ b/src/app/(home)/_components/CommonCategoryCard.tsx
@@ -1,29 +1,18 @@
+import { GetMostPopularCategoriesResponseBody } from "@/api/types/response";
 import { Routes } from "@/utils/constants/routes";
 import { formatToNumber } from "@/utils/intl";
 import { BoxSelect } from "lucide-react";
 import Link from "next/link";
 
-// TODO: Find a way to map the categories to the icons
-
 type Props = {
-  id: number | string;
-  name: string;
-  slug: string;
-  field: string;
-  freelancersCount: number;
+  category: GetMostPopularCategoriesResponseBody[number];
 };
 
-export default function CommonCategoryCard({
-  field,
-  freelancersCount,
-  id,
-  name,
-  slug,
-}: Props) {
+export default function CommonCategoryCard({ category }: Props) {
+  const { name, slug, totalProjects, totalServices } = category;
   return (
     <Link
       href={Routes.singleCategory(slug)}
-      key={id}
       className="px-7 py-10 space-y-7 flex-1 border border-neutral-200 lg:border-neutral-50 lg:shadow-lg hover:bg-neutral-200/40 duration-300 cursor-pointer"
     >
       <div className="relative  inline-block">
@@ -34,9 +23,13 @@ export default function CommonCategoryCard({
         <div className="absolute -z-10 -right-3 -bottom-2 bg-primary-100 w-10 h-10 rounded-full" />
       </div>
       <div className="space-y-1">
-        <p>{formatToNumber(freelancersCount)} prestadores</p>
         <p className="text-lg font-regular min-w-[200px]">{name}</p>
-        <p className="text-neutral-500 min-w-[200px]">{field}</p>
+        <p className="text-neutral-500 min-w-[200px] text-sm">
+          {formatToNumber(totalProjects)} projectos
+        </p>
+        <p className="text-neutral-500 min-w-[200px] text-sm">
+          {formatToNumber(totalServices)} projectos
+        </p>
       </div>
     </Link>
   );

--- a/src/app/(home)/_components/PopularCategoriesLoadingState.tsx
+++ b/src/app/(home)/_components/PopularCategoriesLoadingState.tsx
@@ -1,0 +1,43 @@
+import { Routes } from "@/utils/constants/routes";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+const categories = Array.from({ length: 12 }, (_, i) => ({
+  id: i,
+}));
+
+export default function PopularCategoriesLoadingState() {
+  return (
+    <section className="mt-10 lg:mt-28">
+      <div className="lg:flex items-center justify-between lg:mb-20">
+        <h2 className="text-3xl font-bold mb-14 lg:mb-0">
+          Categorias Mais Populares
+        </h2>
+        <Link
+          href={Routes.categories}
+          className="font-bold group flex items-center gap-2"
+        >
+          Todas as categorias
+          <ArrowRight className="group-hover:translate-x-2 duration-300" />
+        </Link>
+      </div>
+      <article className="mt-5 flex overflow-auto gap-2 lg:grid grid-cols-4 lg:gap-7 lg:mt-0 lg:py-4 lg:overflow-hidden">
+        {categories.map(({ id }) => (
+          <div
+            className="px-7 py-10 space-y-7 flex-1 border border-neutral-200 lg:border-neutral-50 lg:shadow-lg hover:bg-neutral-200/40 duration-300 cursor-pointer"
+            key={id}
+          >
+            <div className="relative  inline-block">
+              <div className="animate-pulse bg-primary-100 w-10 h-10 rounded-full" />
+            </div>
+            <div className="space-y-1">
+              <div className="animate-pulse bg-primary-100 w-3/4 h-6 rounded" />
+              <div className="animate-pulse bg-primary-100 w-1/2 h-4 rounded" />
+              <div className="animate-pulse bg-primary-100 w-1/2 h-4 rounded" />
+            </div>
+          </div>
+        ))}
+      </article>
+    </section>
+  );
+}

--- a/src/app/(home)/_components/PopularCategoryIconSelector.tsx
+++ b/src/app/(home)/_components/PopularCategoryIconSelector.tsx
@@ -1,0 +1,63 @@
+import {
+  BoxSelect,
+  Briefcase,
+  Camera,
+  Car,
+  Code,
+  Droplets,
+  Edit3,
+  Eraser,
+  Paintbrush,
+  Presentation,
+  School,
+  Unplug,
+  Utensils,
+} from "lucide-react";
+
+type Props = {
+  slug: string;
+};
+
+export default function PopularCategoryIconSelector({ slug }: Props) {
+  const className = "text-primary-600 relative category-bg-icon";
+  const size = 40;
+  switch (slug) {
+    case "desenvolvimento-de-software":
+      return <Code size={size} className={className} />;
+
+    case "alimentacao-e-culinaria":
+      return <Utensils size={size} className={className} />;
+
+    case "consultoria-de-negocios":
+      return <Briefcase size={size} className={className} />;
+
+    case "design-e-criacao":
+      return <Paintbrush size={size} className={className} />;
+
+    case "educacao-e-tutoria":
+      return <School size={size} className={className} />;
+
+    case "encanamento-e-hidraulica":
+      return <Droplets size={size} className={className} />;
+
+    case "fotografia":
+      return <Camera size={size} className={className} />;
+
+    case "instalacao-e-manutencao-electrica":
+      return <Unplug size={size} className={className} />;
+
+    case "limpeza-e-organizacao":
+      return <Eraser size={size} className={className} />;
+
+    case "marketing-digital":
+      return <Presentation size={size} className={className} />;
+
+    case "mecanica-e-manutencao-automotiva":
+      return <Car size={size} className={className} />;
+
+    case "redacao-e-traducao":
+      return <Edit3 size={size} className={className} />;
+    default:
+      return <BoxSelect size={size} className={className} />;
+  }
+}

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,8 +1,10 @@
 import Container from "@/components/common/Container";
 import { Metadata } from "next";
-import CommonCategoriesList from "./_components/CommonCategoriesList";
+import { Suspense } from "react";
+import PopularCategories from "./_components/CommonCategoriesList";
 import CoreFeatures from "./_components/CoreFeatures";
 import NewProvidersSection from "./_components/NewProvidersSection";
+import PopularCategoriesLoadingState from "./_components/PopularCategoriesLoadingState";
 import TrendingServicesList from "./_components/TrendingServicesList";
 
 export const metadata: Metadata = {
@@ -15,7 +17,9 @@ export default function HomePage() {
   return (
     <main>
       <Container small>
-        <CommonCategoriesList />
+        <Suspense fallback={<PopularCategoriesLoadingState />}>
+          <PopularCategories />
+        </Suspense>
       </Container>
       <div className="mt-20 bg-primary-50 py-10 lg:py-28">
         <TrendingServicesList />


### PR DESCRIPTION
- Add real data and stream the categories listing section
- Bump lucide-react version
- Add icons for each slug
